### PR TITLE
Removes erroneous dependency

### DIFF
--- a/frontend/tasty-trade/package.json
+++ b/frontend/tasty-trade/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
-    "@expo/webpack-config": "~19.0.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-google-signin/google-signin": "^13.1.0",


### PR DESCRIPTION
Removes @expo/webpack-config as it's incompatible with Expo v51 which… is needed to use the Expo Mobile App.

There seems to not be a need for the dependency anyways and we'll fix issues as it comes up.