### PR TITLE
Added a fix for retrieving posts in case there are no posts.

### DIFF
--- a/frontend/app/(tabs)/post.tsx
+++ b/frontend/app/(tabs)/post.tsx
@@ -64,7 +64,7 @@ export default function MyPost() {
     if (userDocSnap.exists()) {
       const postIds = userDocSnap.data().posts;
 
-      if (postIds) {
+      if (postIds && postIds.length > 0) {
         // (Inner function): For each post, retrieve the data from the "posts" database and return as a Post object.
         const postPromises = postIds.map(async (postId: string) => {
           const postDocRef = doc(db, "posts", postId);


### PR DESCRIPTION
"if (postIds) { ... }" might have been insufficient to check whether posts exist or not and caused an unhandled handler error.

(Might be a point of error in the future)